### PR TITLE
Change tool errors from protocol errors to actual tool result errors

### DIFF
--- a/resources/get_storage_templates.go
+++ b/resources/get_storage_templates.go
@@ -21,15 +21,15 @@ func GetStorageTemplate(gs *gsclient.Client) HandlerFactory {
 		handler := Handler(func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 			templates, err := gs.GetTemplateList(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get storage templates: %w", err)
+				return nil, fmt.Errorf("failed to get storage templates: %w", err) // TODO: Return mcp result/tool/resource error instead of mcp protocol error
 			}
 			if len(templates) == 0 {
-				return nil, fmt.Errorf("no storage templates found")
+				return nil, fmt.Errorf("no storage templates found") // TODO: Return mcp result/tool/resource error instead of mcp protocol error
 			}
 
 			templatesJSON, err := json.Marshal(templates)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal templates to JSON: %w", err)
+				return nil, fmt.Errorf("failed to marshal templates to JSON: %w", err) // TODO: Return mcp result/tool/resource error instead of mcp protocol error
 			}
 
 			return []mcp.ResourceContents{

--- a/tools/create_ip.go
+++ b/tools/create_ip.go
@@ -25,7 +25,7 @@ func CreateIP(gs *gsclient.Client) HandlerFactory {
 			if ip, err := util.GetIntParam(request.Params.Arguments, "family"); err == nil {
 				gsRequest.Family = gsclient.IPAddressType(ip)
 			} else {
-				return nil, fmt.Errorf("failed to get ip: %w", err)
+				return newUnparsableIntErrorResult("family", err)
 			}
 
 			if name, ok := request.Params.Arguments["name"]; ok {
@@ -34,7 +34,7 @@ func CreateIP(gs *gsclient.Client) HandlerFactory {
 
 			gsResponse, err := gs.CreateIP(ctx, gsRequest)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create ip: %w", err)
+				return mcp.NewToolResultErrorFromErr("failed to create ip", err), nil
 			}
 
 			return mcp.NewToolResultText(fmt.Sprintf("IP %s created with ID: %s", gsResponse.IP, gsResponse.ObjectUUID)), nil

--- a/tools/create_storage.go
+++ b/tools/create_storage.go
@@ -37,14 +37,14 @@ func CreateStorage(gs *gsclient.Client) HandlerFactory {
 
 			capacity, err := util.GetIntParam(request.Params.Arguments, "capacity")
 			if err != nil {
-				return nil, fmt.Errorf("capacity parameteris not valid: %w", err)
+				return newUnparsableIntErrorResult("capacity", err)
 			}
 			gsRequest.Capacity = capacity
 
 			// TODO: Check if we can somehow report progress back to the client. The mcp doc says: Use progress reporting for long operations https://modelcontextprotocol.io/docs/concepts/tools
 			gsResponse, err := gs.CreateStorage(ctx, gsRequest)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get create storage: %w", err)
+				return mcp.NewToolResultErrorFromErr("failed to create storage", err), nil
 			}
 
 			return mcp.NewToolResultText(fmt.Sprintf("Storage created with ID: %s", gsResponse.ObjectUUID)), nil

--- a/tools/delete_ip.go
+++ b/tools/delete_ip.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -20,7 +19,7 @@ func DeleteIP(gs *gsclient.Client) HandlerFactory {
 		handler := Handler(func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			err := gs.DeleteIP(ctx, request.Params.Arguments["uuid"].(string))
 			if err != nil {
-				return nil, fmt.Errorf("failed to delete ip: %w", err)
+				return mcp.NewToolResultErrorFromErr("failed to delete IP", err), nil
 			}
 
 			return mcp.NewToolResultText("IP has been deleted"), nil

--- a/tools/err.go
+++ b/tools/err.go
@@ -1,0 +1,11 @@
+package tools
+
+import (
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func newUnparsableIntErrorResult(param string, err error) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultErrorFromErr(fmt.Sprintf("invalid %q given, it must be parsable as integer", param), err), nil
+}


### PR DESCRIPTION
This ensures LLMs get proper error messages which they may use for error handling.